### PR TITLE
[🐸 Frogbot] Update version of com.thoughtworks.xstream:xstream to 1.4.20

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -146,7 +146,7 @@
     <webwolf.context>/</webwolf.context>
     <wiremock.version>2.27.2</wiremock.version>
     <xml-resolver.version>1.2</xml-resolver.version>
-    <xstream.version>1.4.5</xstream.version>
+    <xstream.version>1.4.20</xstream.version>
     <!-- do not update necessary for lesson -->
     <zxcvbn.version>1.8.0</zxcvbn.version>
   </properties>


### PR DESCRIPTION


[comment]: <> (FrogbotReviewComment)

<div align='center'>

[![🚨 This automated pull request was created by Frogbot and fixes the below:](https://raw.githubusercontent.com/jfrog/frogbot/master/resources/v2/vulnerabilitiesFixBannerPR.png)](https://docs.jfrog-applications.jfrog.io/jfrog-applications/frogbot)

</div>


## 📦 Vulnerable Dependencies

### ✍️ Summary
<div align='center'>

| SEVERITY                | CONTEXTUAL ANALYSIS                  | DIRECT DEPENDENCIES                  | IMPACTED DEPENDENCY                  | FIXED VERSIONS                  | CVES                  |
| :---------------------: | :-----------------------------------: | :-----------------------------------: | :-----------------------------------: | :-----------------------------------: | :-----------------------------------: |
| ![](https://raw.githubusercontent.com/jfrog/frogbot/master/resources/v2/applicableCriticalSeverity.png)<br>Critical | Applicable | com.thoughtworks.xstream:xstream:1.4.5 | com.thoughtworks.xstream:xstream 1.4.5 | [1.4.11]<br>[1.4.7] | CVE-2013-7285 |

</div>


### 🔬 Research Details


**Description:**
[XStream](http://x-stream.github.io/) is a Java serialization library to serialize objects, mainly to and from XML but also from other supported formats such as JSON. As it performs the notoriously dangerous action of serialization, 18 vulnerabilities have been discovered in it from version 1.4.6 to 1.4.16. 

The processed stream at unmarshalling time contains type information to recreate the formerly written objects. XStream creates therefore new instances based on these type information. An attacker can manipulate the processed input stream and replace or inject objects, that can execute arbitrary shell commands.

To exploit the vulnerability, an attacker must be able to supply arbitrary input to the `xstream.fromXML`  function (note that the function may accept both XML and JSON serialized streams, not just XML)

Several [proof-of-concepts](https://web.archive.org/web/20160226193607/http://blog.diniscruz.com/2013/12/xstream-remote-code-execution-exploit.html) exist which demonstrate code execution via crafted XML files.

**Remediation:**
##### Development mitigations

Define a whitelist of classes that are accepted by XStream during unmarshalling, by using the built-in [XStream security API](https://x-stream.github.io/security.html#example). Here is an example for such preventive code, to be used when initializing the `XStream` library: 
```java
XStream xstream = new XStream();

// Clear out existing permissions and start a whitelist
xstream.addPermission(NoTypePermission.NONE);

// Allow some basics
xstream.addPermission(NullPermission.NULL);
xstream.addPermission(PrimitiveTypePermission.PRIMITIVES);
xstream.allowTypeHierarchy(Collection.class);

// Allow any type from the "Example" package
xstream.allowTypesByWildcard(new String[] {
    Example.class.getPackage().getName()+".*"
});

// xstream.fromXML() calls from here on out will only deserialize the whitelisted classes
```

It is also possible to implement the `setupConverter` method of XStream to register just the converters the application's use case requires. Both of these methods could block malicious conversions that are able to bypass the default blacklist implemented by XStream as was the case in previous vulnerabilities discovered in the past.


---
<div align='center'>

[🐸 JFrog Frogbot](https://docs.jfrog-applications.jfrog.io/jfrog-applications/frogbot)

</div>
